### PR TITLE
chore: deploy lotti page via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,33 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/public/lotti.html
+++ b/public/lotti.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Lotti</title>
+</head>
+<body>
+  <h1>Hello Lotti!</h1>
+  <p>This page is deployed with GitHub Pages.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add lotti.html sample page
- deploy public folder with GitHub Pages workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c317b842088321b2f0e230cdc76ad9