### PR TITLE
Fix particle burst loop in Lotti page

### DIFF
--- a/public/lotti.html
+++ b/public/lotti.html
@@ -230,10 +230,10 @@
   function renderArt(card){ if(!card){ artEl.innerHTML=cardBackSVG(); return; } if(card.type==='K'){ artEl.innerHTML=carrotSVG(); return; } if(card.custom){ artEl.innerHTML=customSVG(card.label); return; } artEl.innerHTML=numberSVG(card.type); }
 
   // Particles (confetti burst around card center)
-  const fx = $('#fx'); const ctx = fx.getContext('2d'); let particles=[]; let anim=null; let dpr=window.devicePixelRatio||1;
+  const fx = $('#fx'); const ctx = fx.getContext('2d'); let particles=[]; let anim=null; let dpr=window.devicePixelRatio||1; let burstId=0;
   function sizeFX(){ const r=fx.getBoundingClientRect(); fx.width=Math.round(r.width*dpr); fx.height=Math.round(r.height*dpr); }
   function burst(theme){
-    cancelAnimationFrame(anim); sizeFX(); particles=[];
+    cancelAnimationFrame(anim); sizeFX(); particles=[]; const id=++burstId;
     const cardRect = $('#card').getBoundingClientRect(); const fxRect = fx.getBoundingClientRect();
     const cx = (cardRect.left + cardRect.width/2 - fxRect.left)*dpr; const cy = (cardRect.top + cardRect.height/2 - fxRect.top)*dpr;
     const N = 70; const cols = theme==='carrot' ? ['#f59e0b','#fb923c','#fde68a','#34d399','#22d3ee'] : ['#60a5fa','#34d399','#a7f3d0','#22d3ee'];
@@ -241,8 +241,8 @@
       const a = Math.random()*Math.PI*2; const v = 2 + Math.random()*4; const sz = 2 + Math.random()*6;
       particles.push({x:cx,y:cy, vx:Math.cos(a)*v*dpr, vy:Math.sin(a)*v*dpr-2*dpr, r:sz*dpr, rot:Math.random()*Math.PI, vr:(Math.random()-.5)*0.2, life:700+Math.random()*400, t:0, color:cols[i%cols.length], shape: Math.random()<0.5?'rect':'circ'});
     }
-    const start=performance.now();
-    (function loop(now){ const dt = now - (particles._last||now); particles._last=now; ctx.clearRect(0,0,fx.width,fx.height); let alive=false; for(const p of particles){ p.t += dt; if(p.t>p.life) continue; alive=true; p.vy += 0.015*dpr*dt; p.x += p.vx; p.y += p.vy; p.rot += p.vr; const alpha = Math.max(0, 1 - p.t/p.life); ctx.globalAlpha = alpha; ctx.fillStyle = p.color; ctx.save(); ctx.translate(p.x, p.y); ctx.rotate(p.rot); if(p.shape==='rect'){ ctx.fillRect(-p.r, -p.r*0.6, p.r*2, p.r*1.2); } else { ctx.beginPath(); ctx.arc(0,0,p.r,0,Math.PI*2); ctx.fill(); } ctx.restore(); }
+    const start=performance.now(); let last=start;
+    (function loop(now){ if(id!==burstId) return; const dt = now - last; last=now; ctx.clearRect(0,0,fx.width,fx.height); let alive=false; for(const p of particles){ p.t += dt; if(p.t>p.life) continue; alive=true; p.vy += 0.015*dpr*dt; p.x += p.vx; p.y += p.vy; p.rot += p.vr; const alpha = Math.max(0, 1 - p.t/p.life); ctx.globalAlpha = alpha; ctx.fillStyle = p.color; ctx.save(); ctx.translate(p.x, p.y); ctx.rotate(p.rot); if(p.shape==='rect'){ ctx.fillRect(-p.r, -p.r*0.6, p.r*2, p.r*1.2); } else { ctx.beginPath(); ctx.arc(0,0,p.r,0,Math.PI*2); ctx.fill(); } ctx.restore(); }
       ctx.globalAlpha=1; if(alive){ anim=requestAnimationFrame(loop);} }) (start);
   }
   window.addEventListener('resize', sizeFX, {passive:true}); sizeFX();

--- a/tests/test_particle_burst.py
+++ b/tests/test_particle_burst.py
@@ -1,0 +1,23 @@
+import subprocess, textwrap
+
+
+def test_burst_stops_previous_animation():
+    js = textwrap.dedent('''
+    let frames=0;
+    function requestAnimationFrame(fn){ return setTimeout(()=>{ frames++; fn(performance.now()); }, 16); }
+    function cancelAnimationFrame(id){ clearTimeout(id); }
+    let particles=[]; let anim=null; let dpr=1; let burstId=0;
+    function burst(){
+      cancelAnimationFrame(anim); particles=[]; const id=++burstId;
+      particles.push({t:0,life:50});
+      const start=performance.now(); let last=start;
+      (function loop(now){ if(id!==burstId) return; const dt=now-last; last=now; let alive=false;
+        for(const p of particles){ p.t+=dt; if(p.t>p.life) continue; alive=true; }
+        if(alive){ anim=requestAnimationFrame(loop); }
+      })(start);
+    }
+    for(let i=0;i<6;i++){ burst(); }
+    setTimeout(()=>{ console.log(frames); }, 100);
+    ''')
+    out = subprocess.check_output(['node','-e', js], text=True).strip()
+    assert int(out) < 10


### PR DESCRIPTION
## Summary
- prevent overlapping particle animations by tracking burst IDs
- add unit test ensuring previous animations stop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c431e298608321a40b9a5c375582cb